### PR TITLE
Fixed typo in View Properties section

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ basicAnimation.toValue= @(0); // scale from 0 to 1
 ##### Color - kPOPViewBackgroundColor
 ```objective-c
 POPSpringAnimation *basicAnimation = [POPSpringAnimation animation];
-basicAnimation.property = [POPAnimatableProperty propertyWithName: kPOPLayerBackgroundColor];
+basicAnimation.property = [POPAnimatableProperty propertyWithName: kPOPViewBackgroundColor];
 basicAnimation.toValue= [UIColor redColor];
 ```
 


### PR DESCRIPTION
The `kPOPLayerBackgroundColor` in the code sample of _View Properties_ section suppose to be `kPOPViewBackgroundColor`
